### PR TITLE
Update with React v15.5, add prop-types to dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ if (!packageJson.scripts.hasOwnProperty('eject')) {
 const SpawnHelper = require('./helpers').spawnHelper;
 const FormatHelper = require('./helpers').formatHelper;
 
-const deps = ['redux', 'react-redux'];
+const deps = ['redux', 'react-redux', 'prop-types'];
 
 //eject app
 const eject = new SpawnHelper();

--- a/templates/components/PeopleContainer.js
+++ b/templates/components/PeopleContainer.js
@@ -1,4 +1,5 @@
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import * as peopleActions from '../actions/people-actions';

--- a/templates/components/PeopleList.js
+++ b/templates/components/PeopleList.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Person from './Person';
 
 const PeopleList = ({people}) => {

--- a/templates/components/Person.js
+++ b/templates/components/Person.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const Person = ({person}) => {
   return (

--- a/templates/components/PersonInput.js
+++ b/templates/components/PersonInput.js
@@ -1,4 +1,5 @@
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
 class PersonInput extends Component {
   constructor(props) {


### PR DESCRIPTION
React.PropTypes is deprecated as of React v15.5
https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html